### PR TITLE
Theming settings, find & replace items

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
 # Theme - itg.flat
 
 The official itg.flat dark theme for Atom.
+
+
+*__NOTE:__ thank you to __@jesseweed__ (creator of [Seti UI](https://github.com/jesseweed/seti-ui)) for the scrollbar code*

--- a/index.less
+++ b/index.less
@@ -16,3 +16,4 @@
 @import "styles/tree-view";
 @import "styles/utilities";
 @import "styles/zen";
+@import "styles/settings";

--- a/styles/atom.less
+++ b/styles/atom.less
@@ -7,3 +7,22 @@
 atom-workspace {
   background-color: @app-background-color;
 }
+
+// Scrollbar colors (thanks to @jesseweed creator of SetiUI)
+.scrollbars-visible-always {
+  /deep/ ::-webkit-scrollbar {
+    width: 10px;
+    height: 10px;
+  }
+
+  /deep/ ::-webkit-scrollbar-track,
+  /deep/ ::-webkit-scrollbar-corner {
+    background: @scrollbar-background-color;
+  }
+
+  /deep/ ::-webkit-scrollbar-thumb {
+    background: @scrollbar-color;
+    border-radius: 5px;
+    box-shadow: 0 0 1px @scrollbar-shadow-color inset;
+  }
+}

--- a/styles/editor.less
+++ b/styles/editor.less
@@ -1,7 +1,6 @@
 @import "ui-variables";
 @import "ui-mixins";
 
-
 atom-text-editor[mini] {
   line-height: 40px;
   max-height: 40px;
@@ -41,6 +40,18 @@ atom-text-editor .highlighted.selection .region {
   -webkit-animation-iteration-count: 1;
 }
 
+// find/replace background highlight colors
+atom-text-editor::shadow .highlight {
+  &.find-result .region {
+    background: @find-result-background-color;
+    border: 1px dashed @find-result-border-color;
+  }
+  &.current-result .region,
+  &.current-result ~ .highlight.selection .region {
+    background: @find-result-current-background-color; // to distinguish from the other results
+    border: 1px dashed @find-result-current-border-color;
+  }
+}
 
 // theming Terminal Status
 .cli-status {

--- a/styles/settings.less
+++ b/styles/settings.less
@@ -1,0 +1,74 @@
+@import "ui-variables";
+
+.settings-view {
+    // side nav
+    .config-menu {
+        // selected tab
+        .nav > li.active > a {
+            color: white;
+            font-weight: 200;
+        }
+        // icon color for non-selected tabs
+        li:not(.active) .icon:before {
+            color: lighten(@primary-color, 5%);
+        }
+        // hover effect for non-selected tab text & icon
+        .nav > li:not(.active) > a:hover {
+            color: lighten(@light-grey, 20%);
+
+            &:before {
+                color: @primary-color;
+            }
+        }
+    }
+
+    // section headings
+    section .section-heading,
+    .section .section-heading {
+        color: white;
+    }
+
+    // select box
+    select.form-control {
+        border: 1px solid @primary-color;
+        background: @primary-color;
+        color: @white;
+
+        &:hover, &:focus, &:visited {
+            background: lighten(@primary-color, 5%);
+        }
+    }
+
+    .card-name a { .link-color }
+    .package-card {
+        .meta-user .author { .link-color }
+        .stats .stats-item .icon { color: lighten(@primary-color, 5%); }
+    }
+    .link { .link-color }
+
+    .btn {
+        &:hover {
+            background: @primary-color;
+            color: white;
+        }
+        &.selected {
+            background: @light-grey;
+            color: white;
+        }
+    }
+
+    .alert-info {
+        color: @white;
+        background: @light-grey;
+        border: none;
+    }
+}
+
+// re-usable link coloring
+.link-color {
+    color: @primary-color;
+    &:hover {
+        text-decoration: none;
+        color: lighten(@primary-color, 5%);
+    }
+}

--- a/styles/ui-variables.less
+++ b/styles/ui-variables.less
@@ -26,9 +26,7 @@
 @light-primary-color: @light-red;
 
 
-
 // Colors
-
 @text-color: @white;
 @text-color-subtle: #66676c;
 @text-color-highlight: @light-grey;
@@ -81,11 +79,13 @@
 @overlay-background-color: @primary-dark;
 @overlay-border-color: @primary-dark;
 
+
 // BUTTON
 @button-background-color: @primary-dark;
 @button-background-color-hover: @light-white;
 @button-background-color-selected: @primary-color;
 @button-border-color: transparent;
+
 
 // TABS
 @tab-bar-background-color: @primary-dark;
@@ -94,6 +94,7 @@
 @tab-background-color-active: @white;
 @tab-background-color-hover: @light-white;
 @tab-border-color: transparent;
+
 
 // TREE VIEW
 @tree-view-background-color: @primary-dark;
@@ -106,8 +107,20 @@
 @ui-site-color-5: #f5e11d; // yellow
 
 
-// Sizes
+// Find/Replace Highlight Color
+@find-result-background-color: rgba(250, 246, 141, .5);
+@find-result-border-color: rgba(250, 246, 141, .3);
+@find-result-current-background-color: rgba(255, 191, 0, 0.45);
+@find-result-current-border-color: @primary-color;
 
+
+// Scrollbar colors (thanks to @jesseweed creator of SetiUI)
+@scrollbar-background-color: rgba(47, 48, 50, .4);
+@scrollbar-color: rgba(65, 69, 78, .5);
+@scrollbar-shadow-color: rgba(26, 26, 27, 1);
+
+
+// Sizes
 @font-size: 12px;
 
 @disclosure-arrow-size: 12px;
@@ -122,5 +135,4 @@
 
 
 // Other
-
 @font-family: 'Lucida Grande', 'Segoe UI', sans-serif;


### PR DESCRIPTION
1) Theming the settings panel (issue #1). Adding `settings.less`
containing styles. It didn’t have too far to go to tie in with the
theme, mostly just accessorizing with the `@primary-color` var.
2) Theming Find & Replace. I could barely see them most of the time I
was searching for stuff, so I changed it.
3) Theming scrollbars. Thanks to @jesseweed creator of Seti UI for the
example code from his Atom theme. Credit going into README.md as well
as code comments.
