### PR TITLE
Stop using shadow DOM selectors

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,6 @@
   "repository": "https://github.com/itsthatguy/atom-itg-flat",
   "license": "MIT",
   "engines": {
-    "atom": ">0.50.0"
+    "atom": ">=1.13.0"
   }
 }

--- a/styles/base.less
+++ b/styles/base.less
@@ -5,7 +5,7 @@ atom-text-editor {
   color: @syntax-text-color;
 }
 
-atom-text-editor::shadow {
+atom-text-editor.editor {
 
   .wrap-guide {
     background-color: @syntax-wrap-guide-color;

--- a/styles/editor.less
+++ b/styles/editor.less
@@ -12,7 +12,7 @@ atom-text-editor[mini] {
   padding-left: @component-padding/2;
 }
 
-atom-text-editor[mini]::shadow {
+atom-text-editor[mini].editor {
   .placeholder-text {
     color: @text-color-subtle;
   }

--- a/styles/lists.less
+++ b/styles/lists.less
@@ -91,7 +91,7 @@
   border-radius: @component-border-radius;
   border: 1px solid @overlay-border-color;
 
-  atom-text-editor::shadow {
+  atom-text-editor.editor {
     margin-bottom: @component-padding/2;
   }
 


### PR DESCRIPTION
Atom 1.13 deprecates the use of shadow DOM selectors. Also bumps the required Atom version to >= 1.13.0, as the new selectors won't work on older versions of Atom.
Reference: http://blog.atom.io/2017/01/10/atom-1-13.html